### PR TITLE
fix(encoding): correctly decodes base32 when ignoring padding

### DIFF
--- a/packages/encoding/src/base32/decode.ts
+++ b/packages/encoding/src/base32/decode.ts
@@ -13,7 +13,7 @@ import type DecodeOptions from './DecodeOptions';
  */
 export default function decode(encoded: string, options?: DecodeOptions): Uint8Array {
   if (options?.ignorePadding) {
-    decodeBase32IgnorePadding(encoded);
+    return decodeBase32IgnorePadding(encoded);
   }
 
   return decodeBase32(encoded);


### PR DESCRIPTION
<!--
The title should summarise the purpose of this change.

⚠️**NOTE:** The title must conform to the conventional commit message format outlined in CONTRIBUTING.md document, at the root of the project. This is to ensure the merge commit to the main branch is picked up by the CI and creates an entry in the CHANGELOG.md.
-->

### Description
<!-- Describe your changes in detail -->
#### `@kibisis/encoding`
* Adds return statement when decoding base32 with ignored padding option.

### Type of change
<!-- What type of change does this change introduce? Put an 'x' in all the boxes that apply. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Build configuration (CI configuration, scaffolding etc.)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 📝 Documentation update(s)
- [ ] 📦 Dependency update(s)
- [ ] 👩🏽‍💻 Improve developer experience
- [ ] ⚡ Improve performance
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ♻ Refactor
- [ ] ⏪ Revert changes
- [ ] 🧪 New tests or updates to existing tests
